### PR TITLE
Improved dark-mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       <p>Find and share the best resources to help students prepare for the placements</p>
     </div>
     <div>
-      <p align="end" id="toggle-mode">Toggle Mode</p>
+      <button id="toggle-mode"></button>
     </div>
   </header>
   <div class ="container">
@@ -179,10 +179,10 @@
 
     if (savedMode === "dark") {
       document.body.classList.add("dark-mode");
-      toggleBtn.textContent = "☀️ Light Mode";
+      toggleBtn.textContent = "☀️";
     } else {
       document.body.classList.remove("dark-mode");
-      toggleBtn.textContent = "🌙 Dark Mode";
+      toggleBtn.textContent = "🌙";
     }
   });
 
@@ -191,10 +191,10 @@
     document.body.classList.toggle("dark-mode");
 
     if (document.body.classList.contains("dark-mode")) {
-      toggleBtn.textContent = "☀️ Light Mode";
+      toggleBtn.textContent = "☀️";
       localStorage.setItem("mode", "dark");
     } else {
-      toggleBtn.textContent = "🌙 Dark Mode";
+      toggleBtn.textContent = "🌙";
       localStorage.setItem("mode", "light");
     }
   });

--- a/styles/style.css
+++ b/styles/style.css
@@ -7,14 +7,20 @@ html, body {
 }
 
 header {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
   background-color: #006D77; 
   font-family:'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', 'Lucida Sans Unicode', Geneva, Verdana, sans-serif;
   color: #FFFFFF;
   padding: 16px;
-  text-align: center;
   font-size: 1.5rem;
   letter-spacing: 1px; 
 }
+
+
 
 .container {
   margin: 20px auto;
@@ -268,4 +274,28 @@ header{
 
 .dark-mode #backToTop:hover {
   background-color: #5FCADD;
+}
+
+#toggle-mode{
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background-color:#037b86;
+  border: 1px solid #003B42;
+  width: 50px;
+  height: 40px;
+  border-radius: 50px;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+#toggle-mode:hover{
+  transition: all 1s ease;
+  transform: translateY(-3px);
+}
+
+@media (max-width: 786px) {
+  #toggle-mode{
+    position: static;
+  }
 }


### PR DESCRIPTION
Hi @Varshitha713,
 
I have improved the dark-mode toggle. issue #28 
Changes that I made:

-> switched it to a button instead of plain text.
-> improved alignment, fixed size, and improved UI.
-> added a cursor pointer.
-> responsive.

Here is the look:

before ->

<img width="856" height="306" alt="Screenshot 2025-07-30 121920" src="https://github.com/user-attachments/assets/d9ec3bd1-8041-4fa9-8046-c664aa60af6e" />

After ->

<img width="1898" height="912" alt="Screenshot 2025-07-30 121818" src="https://github.com/user-attachments/assets/52c60c1a-d3af-4b1a-baeb-5455966a531a" />

<img width="1898" height="913" alt="Screenshot 2025-07-30 121844" src="https://github.com/user-attachments/assets/94f4c595-e903-46f5-9caa-d312fb5f65dd" />

<img width="705" height="899" alt="Screenshot 2025-07-30 121832" src="https://github.com/user-attachments/assets/65052165-4cdf-49ba-95b6-257f5c862317" />
