### PR TITLE
Remove Twitter and Facebook logos from footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,10 +283,8 @@
         A community-driven project to share the best placement and learning resources for BTech students.
       </p>
       <div class="social-icons">
-        <a href="#"><i class="fab fa-facebook-f"></i></a>
-        <a href="#"><i class="fab fa-twitter"></i></a>
-        <a href="#"><i class="fab fa-linkedin-in"></i></a>
-        <a href="#"><i class="fab fa-github"></i></a>
+        <a href="https://www.linkedin.com/in/varshitha-macha/" target="blank" rel="noopener noreferrer"><i class="fab fa-linkedin-in"></i></a>
+        <a href="https://github.com/Varshitha713/first-contrib-placement" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i></a>
       </div>
     </div>
 


### PR DESCRIPTION
This update removes the Twitter and Facebook social media icons from the website footer. 
Now, only the LinkedIn and GitHub icons remain visible.

Removed: Twitter and Facebook icons/links from the footer.
Retained: LinkedIn and GitHub icons and added links respectively.
Updated the HTML/CSS accordingly for clean presentation.