### PR TITLE
fix: improved dark mode hover visibility for cards

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -72,12 +72,17 @@ header {
 
 .dark-mode header {
   background: linear-gradient(135deg, #003B42, #005A61);
-  color: #E0F7FA;
+  color: #000000;
 }
 
 .dark-mode .card {
   background-color: #1E2A30;
   color: #E0E0E0;
+  border-left-color: #5FCADD;
+}
+.dark-mode .card:hover{
+  background-color: #404e54;
+  color: #0c0b0b;
   border-left-color: #5FCADD;
 }
 
@@ -87,7 +92,7 @@ header {
 }
 
 .dark-mode .card a:hover {
-  color: #B2EBF2;
+  color: #070707;
   background-color: rgba(95, 202, 221, 0.2);
 }
 


### PR DESCRIPTION


In **dark mode**, when hovering over a card, the text color became white against the background, making it difficult to read.
✅ Solution
- Updated `.dark-mode .card:hover` style:
  - Set background color to `#404e54` for better contrast
  - Adjusted text color to `#0c0b0b` for readability
  - Kept the left border highlight (`#5FCADD`) for design consistency

Before
<img width="880" height="695" alt="Screenshot 2025-08-23 141633" src="https://github.com/user-attachments/assets/73e7414b-6c75-4f0d-9d46-52704e5dbda5" />

After
<img width="1039" height="570" alt="Screenshot 2025-08-23 144927" src="https://github.com/user-attachments/assets/ce8b0c3a-e2e3-436f-b2ac-4e14a5ce04f6" />

#184